### PR TITLE
Clean up chunk migration utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Several environment variables control how WhisperX runs:
 - `COMPUTE_TYPE` – computation precision (`int8` by default)
 - `LANGUAGE` – language code (`en` by default)
 - `PYANNOTE_DIARIZATION_AUTH_TOKEN` – token for speaker diarization
+- `BASE_TIMESTAMP_PATH` – dot-delimited path within the document containing the
+  creation timestamp used when prefixing transcript chunks
 
 ### Running manually
 

--- a/packages/home_index_transcribe/chunk_utils.py
+++ b/packages/home_index_transcribe/chunk_utils.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime, timedelta
+
+
+BASE_TIMESTAMP_PATH = os.environ.get("BASE_TIMESTAMP_PATH")
+
+
+def _get_base_timestamp(document):
+    """Return a datetime parsed from ``document`` using ``BASE_TIMESTAMP_PATH``."""
+    if not BASE_TIMESTAMP_PATH or document is None:
+        return None
+
+    value = document
+    for part in BASE_TIMESTAMP_PATH.split("."):
+        if isinstance(value, dict):
+            value = value.get(part)
+        else:
+            return None
+
+    try:
+        return datetime.fromtimestamp(float(value))
+    except Exception:
+        return None
+
+
+def segments_to_chunk_docs(segments, file_id, document=None, module_name="chunk"):
+    """Convert raw whisper segments to chunk documents.
+
+    ``module_name`` is included in the generated chunk identifier so chunks can
+    be deterministically addressed in Meilisearch.
+    """
+    docs = []
+
+    base_ts = _get_base_timestamp(document)
+
+    for idx, segment in enumerate(segments):
+        text = segment.get("text")
+        if not text:
+            continue
+
+        if base_ts:
+            ts = base_ts + timedelta(seconds=float(segment.get("start", 0)))
+            timestamp = ts.strftime("[ts: %Y-%m-%d %H:%M]")
+            text = f"{timestamp}\n{text}"
+
+        docs.append(
+            {
+                "id": f"{module_name}_{file_id}_{idx}",
+                "file_id": file_id,
+                "text": text,
+                "start": segment.get("start"),
+                "end": segment.get("end"),
+            }
+        )
+
+    return docs
+

--- a/packages/home_index_transcribe/migration.py
+++ b/packages/home_index_transcribe/migration.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from .chunk_utils import segments_to_chunk_docs
+
+
+def migrate_v1_segments(name, document, metadata_dir_path):
+    """Move stored segments from document[name] to chunks.json if present."""
+    if name not in document or "segments" not in document[name]:
+        return None, []
+
+    segments = document[name].pop("segments")
+    chunks_path = Path(metadata_dir_path) / "chunks.json"
+    chunks_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(chunks_path, "w") as file:
+        json.dump(segments, file, indent=4)
+
+    chunk_docs = segments_to_chunk_docs(segments, document["id"], document, name)
+    return segments, chunk_docs

--- a/packages/home_index_transcribe/tests/test_chunks.py
+++ b/packages/home_index_transcribe/tests/test_chunks.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+import sys
+import types
+torch = types.SimpleNamespace(cuda=types.SimpleNamespace(empty_cache=lambda: None))
+sys.modules.setdefault("torch", torch)
+home_index_module = types.ModuleType("home_index_module")
+home_index_module.run_server = lambda *a, **k: None
+sys.modules.setdefault("home_index_module", home_index_module)
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from home_index_transcribe import main as transcribe
+
+def test_migrate_segments_to_chunks(tmp_path):
+    segments = [
+        {"start": 0.0, "end": 1.0, "text": "hello", "words": []},
+        {"start": 1.0, "end": 2.0, "text": "world", "words": []},
+    ]
+    doc = {
+        "id": "file1",
+        "type": "audio/ogg",
+        "paths": {"file1.opus": 1.0},
+        transcribe.NAME: {"segments": segments},
+    }
+    metadata_dir = tmp_path / transcribe.NAME
+    metadata_dir.mkdir(parents=True)
+    with open(metadata_dir / "version.json", "w") as f:
+        json.dump({"version": 1}, f)
+    result = transcribe.run(str(tmp_path / "file1.opus"), doc, metadata_dir)
+    with open(metadata_dir / "chunks.json") as f:
+        stored = json.load(f)
+    assert stored == segments
+    assert transcribe.NAME in result["document"]
+    assert "segments" not in result["document"][transcribe.NAME]
+    assert len(result["chunk_docs"]) == 2
+    assert result["chunk_docs"][0]["text"] == "hello"
+    assert result["chunk_docs"][0]["start"] == 0.0
+    assert result["chunk_docs"][0]["end"] == 1.0
+    assert result["chunk_docs"][0]["id"] == f"{transcribe.NAME}_file1_0"
+
+def test_run_generates_chunks(tmp_path, monkeypatch):
+    class DummyModel:
+        def transcribe(self, audio, language=None, batch_size=None):
+            return {"segments": [{"start":0.0,"end":1.0,"text":"hi","words":[]}]} 
+    class DummyWhisperx:
+        def load_audio(self, fp):
+            return None
+        def align(self, segs, a, m, audio, device):
+            return {"segments": segs}
+        def assign_word_speakers(self, diarize_segments, result):
+            return result
+    transcribe.model = DummyModel()
+    transcribe.align_model = None
+    transcribe.align_metadata = None
+    transcribe.diarize_model = lambda audio: []
+    transcribe.whisperx = DummyWhisperx()
+
+    doc = {"id":"file2","type":"audio/ogg","paths":{"f.opus":1.0}}
+    metadata_dir = tmp_path / transcribe.NAME
+    metadata_dir.mkdir(parents=True)
+    result = transcribe.run(str(tmp_path/"f.opus"), doc, metadata_dir)
+    with open(metadata_dir / "chunks.json") as f:
+        stored = json.load(f)
+    assert stored[0]["text"] == "hi"
+    assert len(result["chunk_docs"]) == 1
+    assert result["document"][transcribe.NAME]["text"] == "hi"
+    assert result["chunk_docs"][0]["start"] == 0.0
+    assert result["chunk_docs"][0]["end"] == 1.0
+    assert result["chunk_docs"][0]["id"] == f"{transcribe.NAME}_file2_0"


### PR DESCRIPTION
## Summary
- factor `segments_to_chunk_docs` into a new `chunk_utils` helper
- generate nicer chunk doc names and uuid identifiers
- migrate v1 segments only when upgrading from version 1
- update `run` to pass file name when creating chunk documents
- adjust tests for new behaviour
- remove `name` from chunk docs and include start/end fields
- add timestamp prefix when parsing date from filename
- use document timestamp for chunk prefixing
- rename migration variable
- use deterministic chunk ids
- return early after migrating v1 segments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f39cfd2cc832bb8be9a179b48c041