### PR TITLE
Implement incremental migration system

### DIFF
--- a/packages/home_index_transcribe/migration.py
+++ b/packages/home_index_transcribe/migration.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from .chunk_utils import segments_to_chunk_docs
 
+# MIGRATIONS[i] runs the upgrade from version i to i+1.
+
 
 def migrate_v1_segments(name, document, metadata_dir_path):
     """Move stored segments from document[name] to chunks.json if present."""
@@ -17,3 +19,21 @@ def migrate_v1_segments(name, document, metadata_dir_path):
 
     chunk_docs = segments_to_chunk_docs(segments, document["id"], document, name)
     return segments, chunk_docs
+
+
+MIGRATIONS = [None, migrate_v1_segments]
+
+
+def apply_migrations(from_version, name, document, metadata_dir_path, target_version):
+    """Run one migration step and return ``(segments, chunk_docs, new_version)``."""
+
+    if from_version >= target_version:
+        return None, [], from_version
+
+    if from_version >= len(MIGRATIONS) or MIGRATIONS[from_version] is None:
+        return None, [], from_version
+
+    migration = MIGRATIONS[from_version]
+    segments, docs = migration(name, document, metadata_dir_path)
+    chunk_docs = docs if docs else []
+    return segments, chunk_docs, from_version + 1

--- a/packages/home_index_transcribe/tests/test_chunks.py
+++ b/packages/home_index_transcribe/tests/test_chunks.py
@@ -67,3 +67,47 @@ def test_run_generates_chunks(tmp_path, monkeypatch):
     assert result["chunk_docs"][0]["start"] == 0.0
     assert result["chunk_docs"][0]["end"] == 1.0
     assert result["chunk_docs"][0]["id"] == f"{transcribe.NAME}_file2_0"
+
+
+def test_multiple_migrations(tmp_path, monkeypatch):
+    from home_index_transcribe import migration
+
+    segments = [{"start": 0.0, "end": 1.0, "text": "hi", "words": []}]
+    doc = {
+        "id": "file3",
+        "type": "audio/ogg",
+        "paths": {"f.opus": 1.0},
+        transcribe.NAME: {"segments": segments},
+    }
+
+    def migrate_v2_to_v3(name, document, metadata_dir_path):
+        document["migrated"] = True
+        return None, []
+
+    monkeypatch.setattr(transcribe, "VERSION", 3)
+    monkeypatch.setattr(migration, "MIGRATIONS", [None, migration.migrate_v1_segments, migrate_v2_to_v3])
+
+    metadata_dir = tmp_path / transcribe.NAME
+    metadata_dir.mkdir(parents=True)
+    with open(metadata_dir / "version.json", "w") as f:
+        json.dump({"version": 1}, f)
+
+    # First call performs the v1 -> v2 migration and should return chunk docs
+    result = transcribe.run(str(tmp_path / "f.opus"), doc, metadata_dir)
+
+    with open(metadata_dir / "version.json") as f:
+        stored_version = json.load(f)
+
+    assert stored_version["version"] == 2
+    assert "migrated" not in doc
+    assert len(result["chunk_docs"]) == 1
+
+    # Second call performs the v2 -> v3 migration
+    result = transcribe.run(str(tmp_path / "f.opus"), doc, metadata_dir)
+
+    with open(metadata_dir / "version.json") as f:
+        stored_version = json.load(f)
+
+    assert stored_version["version"] == 3
+    assert doc["migrated"] is True
+    assert result["chunk_docs"] == []


### PR DESCRIPTION
## Summary
- apply at most one migration per run and exit early
- store updated version after each migration
- update tests for stepwise migrations
- trim migration helper documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f58fc9720832b97031d24bd8da7fc